### PR TITLE
Fix orig_root_dir comparison between str/unicode

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3513,7 +3513,8 @@ class Manage(Home, WebRoot):
                        **kwargs):
         dir_map = {}
         for cur_arg in filter(lambda x: x.startswith('orig_root_dir_'), kwargs):
-            dir_map[kwargs[cur_arg]] = ek(six.text_type, kwargs[cur_arg.replace('orig_root_dir_', 'new_root_dir_')], 'utf-8')
+            orig_root_dir_uni = ek(six.text_type, kwargs[cur_arg], 'utf-8')
+            dir_map[orig_root_dir_uni] = ek(six.text_type, kwargs[cur_arg.replace('orig_root_dir_', 'new_root_dir_')], 'utf-8')
 
         showIDs = toEdit.split("|")
         errors = []


### PR DESCRIPTION
Fixes #5274

Proposed changes in this pull request:
- Make orig_root_dir_* values unicode to fix path comparisons

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
